### PR TITLE
feat: quick preset editor values must be set on creation (#2028)

### DIFF
--- a/frontend/src/variants/components/FilterForm/QuickPresets.vue
+++ b/frontend/src/variants/components/FilterForm/QuickPresets.vue
@@ -323,6 +323,30 @@ const quickPresetWrapper = computed({
   },
 })
 
+const quickPresetsComplete = computed(() => {
+  const result = {}
+  for (const [name, theQuickPresets] of Object.entries(props.quickPresets)) {
+    let skip = false
+    for (const key of [
+      'inheritance',
+      'frequency',
+      'impact',
+      'quality',
+      'chromosomes',
+      'flagsetc',
+    ]) {
+      if (!theQuickPresets[key]) {
+        skip = true
+        break
+      }
+    }
+    if (!skip) {
+      result[name] = theQuickPresets
+    }
+  }
+  return result
+})
+
 /** Refresh all presets. */
 const refreshAllRefs = () => {
   refreshInheritanceRef()
@@ -366,7 +390,7 @@ onMounted(() => {
         v-model="quickPresetWrapper"
         class="custom-select custom-select-sm"
       >
-        <option v-for="(value, name) in quickPresets" :value="name">
+        <option v-for="(value, name) in quickPresetsComplete" :value="name">
           {{ value.label ?? name }}
         </option>
         <option disabled>custom</option>

--- a/frontend/src/variants/components/QueryPresets/SetEditor.vue
+++ b/frontend/src/variants/components/QueryPresets/SetEditor.vue
@@ -250,7 +250,6 @@ const handleAddClicked = async (category) => {
         quality: null,
         chromosome: null,
         flagsetc: null,
-        inheritance: null,
       }
     } else if (category === 'qualitypresets') {
       payload = {

--- a/frontend/src/variants/components/QueryPresets/SetQuickPresets.vue
+++ b/frontend/src/variants/components/QueryPresets/SetQuickPresets.vue
@@ -1,6 +1,8 @@
 <script setup>
 /** Editor component for quick presets.
  */
+import { computed } from 'vue'
+
 import { randomString } from '@/varfish/common'
 
 /** Define props. */
@@ -15,11 +17,31 @@ const props = defineProps({
     default: randomString(),
   },
 })
+
+const isIncomplete = computed(() => {
+  for (const key of [
+    'inheritance',
+    'frequency',
+    'impact',
+    'quality',
+    'chromosome',
+    'flagsetc',
+  ]) {
+    if (!props.querySettings[key]) {
+      return true
+    }
+  }
+  return false
+})
 </script>
 
 <template>
   <!-- eslint-disable -->
   <div v-if="querySettings" class="mr-2 mt-2">
+    <div class="alert alert-warning" v-if="isIncomplete">
+      <strong>Warning!</strong> The query settings are incomplete and will not
+      be available in the filter form unless all values are set.
+    </div>
     <div class="form-group">
       <label :for="'inheritance' + idSuffix"> Inheritance </label>
       <select


### PR DESCRIPTION


<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a computed property for filtering quick presets to ensure only complete options are available.
	- Added a warning message for incomplete query settings in the user interface.

- **Enhancements**
	- Updated preset management to include a new property for better attribute handling in preset categories.

- **Bug Fixes**
	- Ensured that only complete presets are considered during selection, improving the robustness of the component functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->