### PR TITLE
fix: pedigree edits are not saved (#2112)

### DIFF
--- a/backend/cases/serializers.py
+++ b/backend/cases/serializers.py
@@ -167,7 +167,6 @@ class CaseSerializerNg(CoreCaseSerializerMixin, SODARProjectModelSerializer):
             "presetset",  # made writable in to_internal_value
             "state",
             "caseqc",
-            "pedigree",
             "pedigree_obj",
         )
 

--- a/backend/varfish/tests/drf_openapi_schema/varfish_api_schema.yaml
+++ b/backend/varfish/tests/drf_openapi_schema/varfish_api_schema.yaml
@@ -6072,8 +6072,7 @@ components:
         index:
           type: string
           maxLength: 512
-        pedigree:
-          readOnly: true
+        pedigree: {}
         notes:
           type: string
           nullable: true
@@ -6153,6 +6152,7 @@ components:
           type: string
           minLength: 1
           maxLength: 512
+        pedigree: {}
         notes:
           type: string
           nullable: true
@@ -6172,6 +6172,7 @@ components:
       required:
       - index
       - name
+      - pedigree
     CaseSerializerNgStateEnum:
       enum:
       - importing
@@ -8091,6 +8092,7 @@ components:
           type: string
           minLength: 1
           maxLength: 512
+        pedigree: {}
         notes:
           type: string
           nullable: true


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The `presetset` field is now writable, allowing for more flexible data input.
	- The `pedigree` field is no longer read-only, enabling updates.

- **Bug Fixes**
	- Improved validation for the `presetset` field to handle empty and non-existent values more effectively.

- **Documentation**
	- Added detailed descriptions to the OpenAPI schema for various endpoints, enhancing clarity.
	- Updated API documentation to reflect changes in the `pedigree` property structure and requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->