### PR TITLE
fix: empty genotype data in sample cause sv query to crash (#2201)

### DIFF
--- a/backend/svs/models/jobs.py
+++ b/backend/svs/models/jobs.py
@@ -329,7 +329,7 @@ def run_sv_query_bg_job(pk):  # noqa: C901
         }
         # Mapping of key from database JSON keys to VCF coercion function.
         coerce_db_to_vcf = {
-            "cn": lambda x: int(x),
+            "cn": lambda x: x if x == "." else int(x),
         }
 
         # Dump the SVs to a TSV file for processing by the worker


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected handling of missing data in structural variant queries, ensuring missing values are preserved in the output instead of being converted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->