### PR TITLE
feat: remove obsolete models in queries (#2371)

### DIFF
--- a/backend/variants/queries.py
+++ b/backend/variants/queries.py
@@ -29,7 +29,6 @@ from geneinfo.models import (
     GeneIdToInheritance,
     GnomadConstraints,
     Hgnc,
-    MgiMapping,
     RefseqToEnsembl,
     RefseqToGeneSymbol,
     RefseqToHgnc,
@@ -1919,44 +1918,6 @@ class ProjectExportTableQuery(ProjectPrefetchQuery):
 class ProjectExportVcfQuery(ProjectPrefetchQuery):
     builder = ProjectExportVcfQueryPartsBuilder
 
-
-# Query for obtaining the knownGene alignments (used from JSON query).
-
-
-class KnownGeneAAQuery:
-    """Query database for the ``knownGeneAA`` information."""
-
-    def __init__(self, engine):
-        #: The Aldjemy engine to use
-        self.engine = engine
-
-    def run(self, kwargs):
-        """Execute the query."""
-        # TODO: Replace kwargs with actual parameters
-        #
-        # TODO: we should load the alignment based on UCSC transcript ID (without version) and then post-filter
-        # TODO: by column...
-        distinct_fields = [
-            KnowngeneAA.sa.release,
-            KnowngeneAA.sa.chromosome,
-            KnowngeneAA.sa.start,
-            KnowngeneAA.sa.end,
-        ]
-        query = (
-            select(distinct_fields + [KnowngeneAA.sa.alignment])
-            .select_from(KnowngeneAA.sa.table)
-            .where(
-                and_(
-                    KnowngeneAA.sa.release == kwargs["release"],
-                    KnowngeneAA.sa.chromosome == kwargs["chromosome"],
-                    KnowngeneAA.sa.start <= int(kwargs["start"]) + (len(kwargs["reference"]) - 1),
-                    KnowngeneAA.sa.end >= int(kwargs["start"]),
-                )
-            )
-            .order_by(KnowngeneAA.sa.start)
-            .distinct(*distinct_fields)  # DISTINCT ON
-        )
-        return self.engine.execute(query)
 
 
 # Query for deleting the variants of a case.

--- a/backend/variants/queries.py
+++ b/backend/variants/queries.py
@@ -314,24 +314,6 @@ class ExtendQueryPartsGeneSymbolJoin(ExtendQueryPartsBase):
         return [func.coalesce(self.subquery.c.gene_symbol, "").label("gene_symbol")]
 
 
-class ExtendQueryPartsMgiJoin(ExtendQueryPartsBase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.subquery = (
-            select([func.max(MgiMapping.sa.mgi_id).label("mgi_id")])
-            .select_from(MgiMapping.sa)
-            .where(MgiMapping.sa.human_entrez_id == SmallVariant.sa.refseq_gene_id)
-            .group_by(MgiMapping.sa.human_entrez_id)
-            .lateral("mgi_subquery")
-        )
-
-    def extend_fields(self, _query_parts):
-        return [self.subquery.c.mgi_id]
-
-    def extend_selectable(self, query_parts):
-        return query_parts.selectable.outerjoin(self.subquery, true())
-
-
 class ExtendQueryPartsAcmgJoin(ExtendQueryPartsBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1591,7 +1573,6 @@ class QueryPartsBuilder:
             ExtendQueryPartsHgncJoin,
             ExtendQueryPartsGeneSymbolJoin,
             ExtendQueryPartsAcmgJoin,
-            ExtendQueryPartsMgiJoin,
         ]
 
 
@@ -1605,7 +1586,6 @@ class CaseLoadPrefetchedQueryPartsBuilder(QueryPartsBuilder):
             ExtendQueryPartsHgncJoin,
             ExtendQueryPartsGeneSymbolJoin,
             ExtendQueryPartsAcmgJoin,
-            ExtendQueryPartsMgiJoin,
             ExtendQueryPartsFlagsJoinAndFilter,
             ExtendQueryPartsCommentsJoin,
             ExtendQueryPartsCommentsExtraAnnoJoin,
@@ -1638,7 +1618,6 @@ class CaseLoadUserAnnotatedQueryPartsBuilder(QueryPartsBuilder):
             ExtendQueryPartsGnomadConstraintsJoin,
             ExtendQueryPartsHgncJoin,
             ExtendQueryPartsInHouseJoin,
-            ExtendQueryPartsMgiJoin,
             ExtendQueryPartsMitochondrialFrequenciesJoin,
             ExtendQueryPartsModesOfInheritanceJoin,
         ] + get_qp_extender_classes_from_plugins()
@@ -1652,7 +1631,6 @@ class CaseExportTableQueryPartsBuilder(QueryPartsBuilder):
             *extender_classes_base,
             ExtendQueryPartsHgncAndConservationJoin,
             ExtendQueryPartsAcmgJoin,
-            ExtendQueryPartsMgiJoin,
             ExtendQueryPartsGnomadConstraintsJoin,
         ] + get_qp_extender_classes_from_plugins()
 
@@ -1676,7 +1654,6 @@ class ProjectLoadPrefetchedQueryPartsBuilder(QueryPartsBuilder):
             ExtendQueryPartsDbsnpJoin,
             ExtendQueryPartsHgncJoin,
             ExtendQueryPartsGeneSymbolJoin,
-            ExtendQueryPartsMgiJoin,
             ExtendQueryPartsAcmgJoin,
             ExtendQueryPartsFlagsJoin,
             ExtendQueryPartsCommentsJoin,
@@ -1696,7 +1673,6 @@ class ProjectExportTableQueryPartsBuilder(QueryPartsBuilder):
             ExtendQueryPartsHgncAndConservationJoin,
             ExtendQueryPartsGeneSymbolJoin,
             ExtendQueryPartsAcmgJoin,
-            ExtendQueryPartsMgiJoin,
             ExtendQueryPartsGnomadConstraintsJoin,
         ] + get_qp_extender_classes_from_plugins()
 

--- a/backend/variants/queries.py
+++ b/backend/variants/queries.py
@@ -24,7 +24,6 @@ from frequencies.models import HelixMtDb, Mitomap, MtDb
 from geneinfo.models import (
     Acmg,
     EnsemblToGeneSymbol,
-    ExacConstraints,
     GeneIdInHpo,
     GeneIdToInheritance,
     GnomadConstraints,

--- a/backend/variants/serializers/__init__.py
+++ b/backend/variants/serializers/__init__.py
@@ -336,11 +336,6 @@ class SmallVariantForExtendedResultSerializer(serializers.Serializer):
     gnomad_loeuf = serializers.FloatField()
 
     # Joined fields (ExtendQueryPartsExacConstraintsJoin)
-    exac_pLI = serializers.FloatField()
-    exac_mis_z = serializers.FloatField()
-    exac_syn_z = serializers.FloatField()
-
-    # Joined fields (ExtendQueryPartsExacConstraintsJoin)
     inhouse_hom_ref = serializers.IntegerField()
     inhouse_het = serializers.IntegerField()
     inhouse_hom_alt = serializers.IntegerField()

--- a/backend/variants/serializers/__init__.py
+++ b/backend/variants/serializers/__init__.py
@@ -294,9 +294,6 @@ class SmallVariantForExtendedResultSerializer(serializers.Serializer):
     # Joined fields (ExtendQueryPartsAcmgJoin)
     acmg_symbol = serializers.CharField()
 
-    # Joined fields (ExtendQueryPartsMgiJoin)
-    mgi_id = serializers.CharField()
-
     # Joined fields (ExtendQueryPartsFlagsJoinAndFilter)
     flag_count = serializers.IntegerField()
     flag_bookmarked = serializers.BooleanField()

--- a/backend/variants/tests/test_queries.py
+++ b/backend/variants/tests/test_queries.py
@@ -137,8 +137,6 @@ class TestCaseOneLoadSingletonResults(SupportQueryTestBase):
         self.assertTrue(results[0].disease_gene)
         self.assertEqual(results[0].gnomad_pLI, self.gnomad_constraints.pLI)
         self.assertEqual(results[0].exac_pLI, self.exac_constraints.pLI)
-        self.assertEqual(results[0].mgi_id, self.mgi.mgi_id)
-        self.assertIsNone(results[1].mgi_id)
         self.assertFalse(results[1].disease_gene)
 
     def test_load_prefetched_project_cases_results(self):
@@ -150,10 +148,8 @@ class TestCaseOneLoadSingletonResults(SupportQueryTestBase):
         )
         self.assertEqual(results[0].acmg_symbol, self.acmg.symbol)
         self.assertIsNone(results[1].acmg_symbol)
-        self.assertEqual(results[0].mgi_id, self.mgi.mgi_id)
         self.assertTrue(results[0].effect_ambiguity)
         self.assertFalse(results[1].effect_ambiguity)
-        self.assertIsNone(results[1].mgi_id)
 
 
 class TestCaseRefSeqIntergenicPLI(SupportQueryTestBase):

--- a/backend/variants/tests/test_queries.py
+++ b/backend/variants/tests/test_queries.py
@@ -14,7 +14,6 @@ from frequencies.tests.factories import HelixMtDbFactory, MitomapFactory, MtDbFa
 from geneinfo.tests.factories import (
     AcmgFactory,
     EnsemblToGeneSymbolFactory,
-    ExacConstraintsFactory,
     GeneIdInHpoFactory,
     GeneIdToInheritanceFactory,
     GnomadConstraintsFactory,
@@ -98,9 +97,6 @@ class TestCaseOneLoadSingletonResults(SupportQueryTestBase):
         self.gnomad_constraints = GnomadConstraintsFactory(
             ensembl_gene_id=small_vars[0].ensembl_gene_id
         )
-        self.exac_constraints = ExacConstraintsFactory(
-            ensembl_transcript_id=small_vars[0].ensembl_transcript_id
-        )
         # Prepare MGI records
         self.mgi = MgiMappingFactory(human_entrez_id=small_vars[0].refseq_gene_id)
         # Prepare smallvariant query results
@@ -134,7 +130,6 @@ class TestCaseOneLoadSingletonResults(SupportQueryTestBase):
         )
         self.assertTrue(results[0].disease_gene)
         self.assertEqual(results[0].gnomad_pLI, self.gnomad_constraints.pLI)
-        self.assertEqual(results[0].exac_pLI, self.exac_constraints.pLI)
         self.assertFalse(results[1].disease_gene)
 
     def test_load_prefetched_project_cases_results(self):
@@ -190,16 +185,6 @@ class TestCaseRefSeqIntergenicPLI(SupportQueryTestBase):
                 pLI=0.4,
             ),
         ]
-        self.exac_constraints = [
-            ExacConstraintsFactory(
-                ensembl_transcript_id=small_vars[0].ensembl_transcript_id,
-                pLI=1.0,
-            ),
-            ExacConstraintsFactory(
-                ensembl_transcript_id=small_vars[1].ensembl_transcript_id,
-                pLI=0.5,
-            ),
-        ]
         # Prepare smallvariant query results
         self.smallvariantquery = SmallVariantQueryFactory(case=case)
         self.smallvariantquery.query_results.add(small_vars[0].id, small_vars[1].id)
@@ -222,8 +207,6 @@ class TestCaseRefSeqIntergenicPLI(SupportQueryTestBase):
             2,
             query_type="project",
         )
-        self.assertEqual(results[0].exac_pLI, 0.5)
-        self.assertEqual(results[1].exac_pLI, 0.5)
         self.assertEqual(results[0].gnomad_pLI, 0.4)
         self.assertEqual(results[1].gnomad_pLI, 0.4)
 
@@ -234,8 +217,6 @@ class TestCaseRefSeqIntergenicPLI(SupportQueryTestBase):
             2,
             query_type="project",
         )
-        self.assertEqual(results[0].exac_pLI, 1.0)
-        self.assertEqual(results[1].exac_pLI, 0.5)
         self.assertEqual(results[0].gnomad_pLI, 0.8)
         self.assertEqual(results[1].gnomad_pLI, 0.4)
 

--- a/backend/variants/tests/test_queries.py
+++ b/backend/variants/tests/test_queries.py
@@ -8,7 +8,6 @@ Remarks:
 
 from clinvar.tests.factories import ClinvarFactory
 from cohorts.tests.factories import TestCohortBase
-from conservation.tests.factories import KnownGeneAAFactory
 from dbsnp.tests.factories import DbsnpFactory
 from extra_annos.tests.factories import ExtraAnnoFactory
 from frequencies.tests.factories import HelixMtDbFactory, MitomapFactory, MtDbFactory
@@ -31,7 +30,6 @@ from variants.queries import (
     CaseExportVcfQuery,
     CaseLoadPrefetchedQuery,
     CasePrefetchQuery,
-    KnownGeneAAQuery,
     ProjectLoadPrefetchedQuery,
     ProjectPrefetchQuery,
     SmallVariantUserAnnotationQuery,
@@ -5214,84 +5212,6 @@ class TestQueryCohort(TestCohortBase, SupportQueryTestBase):
             12,
             query_type="cohort",
             user=user,
-        )
-
-
-class TestKnownGeneAAQuery(TestBase):
-    """Test the knowngeneaa query."""
-
-    def run_query(self, query_class, kwargs, length):
-        query = query_class(get_engine())
-        results = list(query.run(kwargs))
-        self.assertEqual(len(results), length)
-
-    def setUp(self):
-        super().setUp()
-        self.knowngene = KnownGeneAAFactory(chromosome="1", start=100)
-
-    def test_query_pre_triplet(self):
-        self.run_query(
-            KnownGeneAAQuery,
-            {
-                "release": self.knowngene.release,
-                "chromosome": self.knowngene.chromosome,
-                "start": self.knowngene.start - 1,
-                "end": self.knowngene.end - 1,
-                "reference": "A",
-            },
-            0,
-        )
-
-    def test_query_first_triplet(self):
-        self.run_query(
-            KnownGeneAAQuery,
-            {
-                "release": self.knowngene.release,
-                "chromosome": self.knowngene.chromosome,
-                "start": self.knowngene.start,
-                "end": self.knowngene.start,
-                "reference": "A",
-            },
-            1,
-        )
-
-    def test_query_second_triplet(self):
-        self.run_query(
-            KnownGeneAAQuery,
-            {
-                "release": self.knowngene.release,
-                "chromosome": self.knowngene.chromosome,
-                "start": self.knowngene.start + 1,
-                "end": self.knowngene.end + 1,
-                "reference": "A",
-            },
-            1,
-        )
-
-    def test_query_third_triplet(self):
-        self.run_query(
-            KnownGeneAAQuery,
-            {
-                "release": self.knowngene.release,
-                "chromosome": self.knowngene.chromosome,
-                "start": self.knowngene.start + 2,
-                "end": self.knowngene.start + 2,
-                "reference": "A",
-            },
-            1,
-        )
-
-    def test_query_post_triplet(self):
-        self.run_query(
-            KnownGeneAAQuery,
-            {
-                "release": self.knowngene.release,
-                "chromosome": self.knowngene.chromosome,
-                "start": self.knowngene.start + 3,
-                "end": self.knowngene.end + 3,
-                "reference": "A",
-            },
-            0,
         )
 
 

--- a/frontend/src/variants/components/FilterResultsTable.vue
+++ b/frontend/src/variants/components/FilterResultsTable.vue
@@ -410,21 +410,15 @@ const displayHomozygousContent = (item) => {
 }
 
 const constraintFieldName = computed(() => {
-  return displayConstraint.value === DisplayConstraints.ExacPli.value
-    ? 'exac_pLI'
-    : displayConstraint.value === DisplayConstraints.ExacZMis.value
-      ? 'exac_mis_z'
-      : displayConstraint.value === DisplayConstraints.ExacZSyn.value
-        ? 'exac_syn_z'
-        : displayConstraint.value === DisplayConstraints.GnomadLoeuf.value
-          ? 'gnomad_loeuf'
-          : displayConstraint.value === DisplayConstraints.GnomadPli.value
-            ? 'gnomad_pLI'
-            : displayConstraint.value === DisplayConstraints.GnomadZMis.value
-              ? 'gnomad_mis_z'
-              : displayConstraint.value === DisplayConstraints.GnomadZSyn.value
-                ? 'gnomad_syn_z'
-                : null
+  return displayConstraint.value === DisplayConstraints.GnomadLoeuf.value
+    ? 'gnomad_loeuf'
+    : displayConstraint.value === DisplayConstraints.GnomadPli.value
+      ? 'gnomad_pLI'
+      : displayConstraint.value === DisplayConstraints.GnomadZMis.value
+        ? 'gnomad_mis_z'
+        : displayConstraint.value === DisplayConstraints.GnomadZSyn.value
+          ? 'gnomad_syn_z'
+          : null
 })
 
 const displayConstraintsContent = (item) => {

--- a/frontend/src/variants/enums.ts
+++ b/frontend/src/variants/enums.ts
@@ -143,18 +143,6 @@ export const DisplayFrequencies = Object.freeze({
 })
 
 export const DisplayConstraints = Object.freeze({
-  ExacPli: {
-    value: 0,
-    text: 'ExAC pLI',
-  },
-  ExacZSyn: {
-    value: 1,
-    text: 'ExAC Z syn',
-  },
-  ExacZMis: {
-    value: 2,
-    text: 'ExAC Z mis',
-  },
   GnomadLoeuf: {
     value: 3,
     text: 'gnomAD LOEUF',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed display and filtering options related to ExAC constraint values and MGI IDs from variant results.
  * The following fields are no longer shown: ExAC pLI, ExAC Z syn, ExAC Z mis, and MGI ID.
* **Tests**
  * Removed tests related to ExAC constraint values, MGI IDs, and knownGene amino acid alignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->