### PR TITLE
feat: pulling gnomad constraints for result table from annonars

### DIFF
--- a/backend/variants/file_export.py
+++ b/backend/variants/file_export.py
@@ -25,6 +25,7 @@ from .models import (
     SmallVariantComment,
     VariantScoresFactory,
     annotate_with_gm_scores,
+    annotate_with_gnomad_constraints,
     annotate_with_joint_scores,
     annotate_with_pathogenicity_scores,
     annotate_with_pedia_scores,
@@ -398,7 +399,8 @@ class CaseExporterBase:
         self.job.add_log_entry("Executing database query...")
         with contextlib.closing(self.query.run(self.query_args)) as result:
             self.job.add_log_entry("Executing phenotype score query...")
-            _result = annotate_with_transcripts(list(result), self.query_args["database_select"])
+            _result = annotate_with_gnomad_constraints(list(result))
+            _result = annotate_with_transcripts(_result, self.query_args["database_select"])
             if self._is_prioritization_enabled():
                 gene_scores = self._fetch_gene_scores([entry.entrez_id for entry in _result])
                 _result = annotate_with_phenotype_scores(_result, gene_scores)


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Variant export files now include gene constraint metrics (pLI, misZ, synZ, oeMis, oeLof, LOEUF) sourced from gnomAD via annonars.com.

* **Bug Fixes**
  * Improved annotation pipeline to add gene constraint data before transcript annotation.

* **Tests**
  * Enhanced test coverage for file exports validating new gene constraint fields.
  * Removed outdated tests related to prior gnomAD constraint query integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->