### PR TITLE
fix: sv filter results display hom for ./. genotypes (#2401)

### DIFF
--- a/frontend/src/svs/components/SvFilterResultsTable.vue
+++ b/frontend/src/svs/components/SvFilterResultsTable.vue
@@ -269,22 +269,6 @@ const flagAsArtifact = async (svRecord) => {
   }
 }
 
-// Return label for effective genotype.
-const effectiveGenotype = (callInfo) => {
-  switch (callInfo.effective_genotype) {
-    case 'hom':
-      return 'hom.'
-    case 'het':
-      return 'het.'
-    case 'variant':
-      return 'var.'
-    case 'ref':
-      return 'ref.'
-    case 'non-variant':
-      return 'non-var.'
-  }
-}
-
 const getAcmgRating = (payload) => {
   return svAcmgRatingStore.getAcmgRating(
     new LinearStrucvarImpl(
@@ -875,7 +859,7 @@ watch(
           class="text-center text-nowrap"
           :class="{ 'text-danger': alertOnRefGt(call_info[name]) }"
         >
-          {{ effectiveGenotype(call_info[name]) }}
+          {{ call_info[name].genotype }}
           <span
             v-if="alertOnRefGt(call_info[name])"
             title="REF genotype but variant evidence!"


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated genotype labels in the SV Filter Results table to display the raw genotype values from the data source.
  * Replaced previously abbreviated labels (e.g., hom., het., var., ref., non-var.) with exact values and removed trailing periods for clearer, consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->