### PR TITLE
fix: sv x-recessive preset filters whole genome (#2416)

### DIFF
--- a/backend/svs/query_presets.py
+++ b/backend/svs/query_presets.py
@@ -795,7 +795,7 @@ class _QuickPresetList:
         frequency=Frequency.RELAXED,
         impact=Impact.EXONIC,
         sv_type=SvType.CNVS_EXTRA_LARGE,
-        chromosomes=Chromosomes.WHOLE_GENOME,
+        chromosomes=Chromosomes.X_CHROMOSOME,
         regulatory=Regulatory.DEFAULT,
         tad=Tad.DEFAULT,
         known_patho=KnownPatho.DEFAULT,

--- a/backend/svs/tests/snapshots/snap_test_query_presets.py
+++ b/backend/svs/tests/snapshots/snap_test_query_presets.py
@@ -326,5 +326,5 @@ snapshots["TestQuickPresets::testValueWholeGenome 1"] = GenericRepr(
 )
 
 snapshots["TestQuickPresets::testValueXRecessive 1"] = GenericRepr(
-    "QuickPresets(label='X-recessive', inheritance=<Inheritance.X_RECESSIVE: 'x_recessive'>, frequency=<Frequency.RELAXED: 'relaxed'>, impact=<Impact.EXONIC: 'exonic'>, sv_type=<SvType.CNVS_EXTRA_LARGE: 'cnvs_extra_large'>, chromosomes=<Chromosomes.WHOLE_GENOME: 'whole_genome'>, regulatory=<Regulatory.DEFAULT: 'default'>, tad=<Tad.DEFAULT: 'default'>, known_patho=<KnownPatho.DEFAULT: 'default'>, genotype_criteria=<GenotypeCriteriaDefinitions.SVISH_HIGH: 'svish_high'>, database=<Database.REFSEQ: 'refseq'>)"
+    "QuickPresets(label='X-recessive', inheritance=<Inheritance.X_RECESSIVE: 'x_recessive'>, frequency=<Frequency.RELAXED: 'relaxed'>, impact=<Impact.EXONIC: 'exonic'>, sv_type=<SvType.CNVS_EXTRA_LARGE: 'cnvs_extra_large'>, chromosomes=<Chromosomes.X_CHROMOSOME: 'x_chromosome'>, regulatory=<Regulatory.DEFAULT: 'default'>, tad=<Tad.DEFAULT: 'default'>, known_patho=<KnownPatho.DEFAULT: 'default'>, genotype_criteria=<GenotypeCriteriaDefinitions.SVISH_HIGH: 'svish_high'>, database=<Database.REFSEQ: 'refseq'>)"
 )


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the X-recessive analysis preset to limit queries to the X chromosome instead of the whole genome. This yields more focused results and can reduce noise and runtime for that preset. No user action required; other presets, results, and filters remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->