### PR TITLE
fix: preset editor does not allow empty frequency fields (#2449)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       #
       # - https://stackoverflow.com/questions/64031598
       minio:
-        image: bitnami/minio:latest
+        image: bitnamilegacy/minio:latest
         env:
           MINIO_ROOT_USER: minioadmin
           MINIO_ROOT_PASSWORD: minio-root-password

--- a/backend/variants/models/presets.py
+++ b/backend/variants/models/presets.py
@@ -437,7 +437,7 @@ class PresetSetManager(models.Manager):
 class PresetSet(CloneMixin, models.Model):
     """A set of user-defined presets."""
 
-    _clone_excluded_fields = ("date_created", "date_modified", "sodar_uuid")
+    _clone_excluded_fields = ("date_created", "date_modified", "sodar_uuid", "default_presetset")
     _clone_m2o_or_o2m_fields = (
         "quickpresets_set",
         "frequencypresets_set",

--- a/frontend/src/cases/api/caseListClient.ts
+++ b/frontend/src/cases/api/caseListClient.ts
@@ -60,7 +60,7 @@ export class CaseListClient extends ClientBase {
       'GET',
       null,
       {
-        accept: 'application/vnd.bihealth.sodar-core+json',
+        accept: 'application/vnd.bihealth.sodar-core.projectroles+json',
       },
     )
   }

--- a/frontend/src/varfish/apiUtils.ts
+++ b/frontend/src/varfish/apiUtils.ts
@@ -77,6 +77,39 @@ export class ClientBase {
       },
       body: payload ? JSON.stringify(payload) : null,
     })
+
+    // Check if the response is OK (2xx status codes)
+    if (!response.ok) {
+      // Try to parse error response
+      let errorData
+      try {
+        const responseText = await response.text()
+        console.error('[fetchHelper] Error response body:', responseText)
+        try {
+          errorData = JSON.parse(responseText)
+        } catch {
+          errorData = { detail: responseText || response.statusText }
+        }
+      } catch {
+        // If parsing fails, use status text
+        errorData = { detail: response.statusText }
+      }
+
+      console.error('[fetchHelper] Request failed:', {
+        url,
+        status: response.status,
+        statusText: response.statusText,
+        errorData,
+      })
+
+      // Throw an error with the response data
+      const error = new Error('API request failed')
+      // Attach the error data and response to the error object
+      ;(error as any).response = response
+      ;(error as any).data = errorData
+      throw error
+    }
+
     // TODO: move to deleteHelper?
     if (method === 'DELETE') {
       return null

--- a/frontend/src/variants/components/QueryPresets/SetEditor.vue
+++ b/frontend/src/variants/components/QueryPresets/SetEditor.vue
@@ -216,10 +216,15 @@ const handleSaveClicked = async (category, presetsUuid) => {
     })
   } catch (err) {
     console.error(err)
+    // Extract error message from the Error object
+    const errorMessage =
+      err instanceof Error
+        ? err.message
+        : `There was a problem saving the ${entityLower}.`
     toastRef.value.show({
       level: 'error',
       title: 'Error!',
-      text: `There was a problem saving the ${entityLower}.`,
+      text: errorMessage,
     })
   }
 }


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed preset cloning to correctly exclude the default flag, ensuring clones don't inherit this attribute.
  * Improved handling of empty values in numeric fields for frequency presets.

* **Improvements**
  * Enhanced error messages when saving presets to display specific validation issues from the server.
  * Strengthened API error handling for clearer feedback on failed requests.

* **Tests**
  * Added test coverage for preset cloning behavior and numeric field validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->