### PR TITLE
fix: preset sets of all projects shouldn't be selectable for a case

### DIFF
--- a/frontend/src/cases/views/CaseDetail/CaseDetailPane.vue
+++ b/frontend/src/cases/views/CaseDetail/CaseDetailPane.vue
@@ -142,7 +142,9 @@ const toastRef = ref(null)
  */
 const handleEditQueryPresetsClicked = async () => {
   const queryPresetsClient = new QueryPresetsClient(ctxStore.csrfToken)
-  const allPresets = await queryPresetsClient.listPresetSetAll()
+  const projectPresets = await queryPresetsClient.listPresetSet(
+    props.projectUuid,
+  )
   const projectDefaultPresetSet =
     await queryPresetsClient.retrieveProjectDefaultPresetSet(props.projectUuid)
   caseDetailsStore.projectDefaultPresetSet = projectDefaultPresetSet
@@ -150,7 +152,7 @@ const handleEditQueryPresetsClicked = async () => {
     ? 'Project Default'
     : 'Factory Presets'
   const options = [{ value: null, label: defaultLabel }].concat(
-    allPresets.map((p) => ({
+    projectPresets.map((p) => ({
       value: p.sodar_uuid,
       label:
         p.label +


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Query presets are now correctly scoped to the current project instead of displaying all available presets globally. This ensures you only see and work with presets relevant to your specific project.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->