### PR TITLE
fix: issuing another query might lead to broken results (#2277)

### DIFF
--- a/frontend/src/variants/components/FilterResultsTable.vue
+++ b/frontend/src/variants/components/FilterResultsTable.vue
@@ -711,6 +711,10 @@ watch(
   () => variantResultSetStore.resultSetUuid,
   async (_newValue, _oldValue) => {
     if (_newValue) {
+      // Reset to page 1 when a new query is executed to avoid loading non-existent pages
+      if (_newValue !== _oldValue) {
+        variantResultSetStore.tablePageNo = 1
+      }
       await loadFromServer()
       scrollToLastPosition()
     }


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination behavior when applying new filters. The results table now correctly resets to page 1 when a new query is executed, ensuring users start at the beginning of filtered results instead of remaining on a previous page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->