### PR TITLE
fix: page reload in results table

### DIFF
--- a/frontend/src/variants/components/FilterResultsTable.vue
+++ b/frontend/src/variants/components/FilterResultsTable.vue
@@ -722,9 +722,15 @@ watch(
   () => variantResultSetStore.resultSetUuid,
   async (_newValue, _oldValue) => {
     if (_newValue && _newValue !== _oldValue) {
-      // Reset to page 1 when a new query is executed to avoid loading non-existent pages
-      // The loadFromServer will be triggered by the pagination watcher
-      variantResultSetStore.tablePageNo = 1
+      // Reset to page 1 when a new query is executed to avoid loading non-existent pages.
+      // If we are already on page 1, trigger a reload explicitly because the pagination
+      // watcher will not fire when the value does not change.
+      if (variantResultSetStore.tablePageNo !== 1) {
+        variantResultSetStore.tablePageNo = 1
+        // pagination watcher will call loadFromServer()
+      } else {
+        await loadFromServer()
+      }
       scrollToLastPosition()
     }
   },


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented requests for invalid pages by resetting pagination when the current page exceeds available pages.
  * Improved result-set switching so data loads only when appropriate; changing result sets now resets to page 1 or triggers loading via pagination.
  * Restores previous scroll position after loading when remaining on page 1.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->