### PR TITLE
feat: added used preset names to query settings

### DIFF
--- a/backend/variants/query_schemas.py
+++ b/backend/variants/query_schemas.py
@@ -327,6 +327,10 @@ class CaseQuery:
     mitomap_count: typing.Optional[int] = None
     mitomap_frequency: typing.Optional[float] = None
 
+    _quick_preset_label: typing.Optional[str] = None
+    _quick_preset_label_version: typing.Optional[int] = 1
+    _category_preset_labels: typing.Optional[typing.Dict[str, typing.Optional[str]]] = None
+
 
 class QueryJsonToFormConverter:
     """Helper class"""
@@ -477,6 +481,14 @@ class QueryJsonToFormConverter:
                 result["%s_%s" % (sample, field)] = (
                     None if not value else getattr(value, field, None)
                 )
+
+        # Preserve the quick preset label and version if present
+        if query._quick_preset_label is not None:
+            result["_quick_preset_label"] = query._quick_preset_label
+        if query._quick_preset_label_version is not None:
+            result["_quick_preset_label_version"] = query._quick_preset_label_version
+        if query._category_preset_labels is not None:
+            result["_category_preset_labels"] = query._category_preset_labels
 
         return result, query.VERSION
 

--- a/backend/variants/schemas/case-query-v1.json
+++ b/backend/variants/schemas/case-query-v1.json
@@ -1501,6 +1501,37 @@
           ]
         }
       }
+    },
+    "_quick_preset_label": {
+      "$id": "#/properties/_quick_preset_label",
+      "type": ["string", "null"],
+      "title": "Quick preset label",
+      "description": "Label of the quick preset that was used for this query (for display purposes only)",
+      "default": null
+    },
+    "_quick_preset_label_version": {
+      "$id": "#/properties/_quick_preset_label_version",
+      "type": ["integer", "null"],
+      "title": "Quick preset label version",
+      "description": "Version number of the quick preset label to track changes over time",
+      "default": 1,
+      "minimum": 1
+    },
+    "_category_preset_labels": {
+      "$id": "#/properties/_category_preset_labels",
+      "type": ["object", "null"],
+      "title": "Category preset labels",
+      "description": "Labels of category presets (inheritance, frequency, impact, quality, chromosomes, flagsetc) for display in exports",
+      "default": null,
+      "properties": {
+        "inheritance": {"type": ["string", "null"]},
+        "frequency": {"type": ["string", "null"]},
+        "impact": {"type": ["string", "null"]},
+        "quality": {"type": ["string", "null"]},
+        "chromosomes": {"type": ["string", "null"]},
+        "flagsetc": {"type": ["string", "null"]}
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/frontend/src/variants/components/FilterResultsTable.vue
+++ b/frontend/src/variants/components/FilterResultsTable.vue
@@ -583,6 +583,30 @@ const extraAnnoFields = computed(
   () => variantResultSetStore.extraAnnoFields ?? [],
 )
 
+const queryPresetLabel = computed(() => {
+  // Get the preset label from the executed query if available
+  const storedLabel =
+    variantResultSetStore.query?.query_settings?._quick_preset_label
+
+  // Return the label if present, otherwise show "custom" for queries without a preset
+  if (storedLabel) {
+    return storedLabel
+  }
+  // For queries created before this feature or custom queries
+  if (variantResultSetStore.query?.query_settings) {
+    return 'custom'
+  }
+  // No query loaded yet
+  return '-'
+})
+
+const queryPresetLabelVersion = computed(() => {
+  return (
+    variantResultSetStore.query?.query_settings?._quick_preset_label_version ||
+    null
+  )
+})
+
 const scrollToLastPosition = () => {
   if (variantQueryStore.lastPosition) {
     const elem = document.querySelector('div#app')
@@ -757,6 +781,25 @@ watch(
         <div class="text-center">
           <span id="results-button" class="btn btn-sm btn-outline-secondary">
             {{ variantResultSetStore?.resultSet?.result_row_count }}
+          </span>
+        </div>
+      </div>
+      <div class="pr-3 align-self-start">
+        <div>
+          <label class="font-weight-bold small mb-0 text-nowrap">
+            Quick Preset
+          </label>
+        </div>
+        <div class="text-center">
+          <span
+            class="badge badge-secondary"
+            :title="
+              queryPresetLabelVersion
+                ? `Query quick preset: ${queryPresetLabel} (v${queryPresetLabelVersion})`
+                : `Query quick preset: ${queryPresetLabel}`
+            "
+          >
+            {{ queryPresetLabel }}
           </span>
         </div>
       </div>

--- a/frontend/src/variants/stores/variantQuery.js
+++ b/frontend/src/variants/stores/variantQuery.js
@@ -293,6 +293,12 @@ export const useVariantQueryStore = defineStore('variantQuery', () => {
   })
   /** Default preset set. */
   const defaultPresetSetUuid = ref(null)
+  /** Currently selected quick preset label for display. */
+  const selectedQuickPresetLabel = ref(null)
+  /** Version of the selected quick preset label. */
+  const selectedQuickPresetLabelVersion = ref(1)
+  /** Category preset labels (inheritance, frequency, impact, quality, chromosomes, flagsetc). */
+  const categoryPresetLabels = ref(null)
 
   /** Promise for initialization of the store. */
   const initializeRes = ref(null)
@@ -354,9 +360,14 @@ export const useVariantQueryStore = defineStore('variantQuery', () => {
    */
   const submitQuery = async () => {
     const variantClient = new VariantClient(ctxStore.csrfToken)
+    const settingsWithPreset = copy(querySettings.value)
+    settingsWithPreset._quick_preset_label = selectedQuickPresetLabel.value
+    settingsWithPreset._quick_preset_label_version =
+      selectedQuickPresetLabelVersion.value
+    settingsWithPreset._category_preset_labels = categoryPresetLabels.value
     previousQueryDetails.value = await variantClient.createQuery(
       caseUuid.value,
-      { query_settings: copy(querySettings.value) },
+      { query_settings: settingsWithPreset },
     )
     queryState.value = QueryStates.Running.value
     downloadStatusTsv.value = null
@@ -690,6 +701,9 @@ export const useVariantQueryStore = defineStore('variantQuery', () => {
     queryLogs,
     quickPresets,
     defaultPresetSetUuid,
+    selectedQuickPresetLabel,
+    selectedQuickPresetLabelVersion,
+    categoryPresetLabels,
     categoryPresets,
     extraAnnoFields,
     hpoNames,

--- a/frontend/src/variants/stores/variantResultSet.ts
+++ b/frontend/src/variants/stores/variantResultSet.ts
@@ -131,6 +131,9 @@ export const useVariantResultSetStore = defineStore('variantResultSet', () => {
       // Still fetching the same query; push to query result set.
       resultSet.value = responseResultSetList[0]
       resultSetUuid.value = responseResultSetList[0].sodar_uuid
+      // Also load the query to get query settings including the preset label
+      const query$ = await variantClient.retrieveQuery(queryUuid$)
+      query.value = query$
       refreshDisplayColumns()
     }
   }


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Quick Preset and Category Presets display support throughout the application
  * Quick Preset labels and Category Preset mappings now appear in PDF and DOCX exports
  * Quick Preset badge now displays in filter results with version information
  * Added ability to export filter settings in multiple formats

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->