### PR TITLE
fix: old sv settings are displayed in dropdown

### DIFF
--- a/backend/svs/views/ajax/presets.py
+++ b/backend/svs/views/ajax/presets.py
@@ -118,9 +118,8 @@ class SvQuickPresetsAjaxView(
     versioning_class = VarfishApiVersioning
 
     def get(self, *args, **kwargs):
-        # Include both real presets and aliases for backward compatibility
         presets_dict = {}
-        for name in QUICK_PRESETS.get_all_preset_names():
+        for name in QUICK_PRESETS.get_preset_names():
             presets_dict[name] = getattr(QUICK_PRESETS, name)
         return Response(cattr.unstructure(presets_dict))
 


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The presets API endpoint now returns only real preset names and excludes backward-compatible alias keys from its response.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/varfish-org/varfish-server/pull/2636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->