### PR TITLE
fix: grch38 freq sample count display

### DIFF
--- a/frontend/src/svs/components/SvFilterForm/FrequencyPane.vue
+++ b/frontend/src/svs/components/SvFilterForm/FrequencyPane.vue
@@ -17,7 +17,7 @@ const sampleCounts = computed(() => {
 
   return {
     thousandGenomes: 2504, // GRCh37
-    exac: 60706,           // GRCh37
+    exac: 60706, // GRCh37
     gnomadSv: isGRCh38 ? 63046 : 10738,
   }
 })
@@ -173,7 +173,8 @@ defineExpose({
         <td title="Phase 3 data (healthy individuals)">
           1000 Genomes
           <small class="text-muted"
-            >(samples: {{ sampleCounts.thousandGenomes.toLocaleString() }})</small
+            >(samples:
+            {{ sampleCounts.thousandGenomes.toLocaleString() }})</small
           >
         </td>
         <td>

--- a/frontend/src/svs/components/SvFilterForm/FrequencyPane.vue
+++ b/frontend/src/svs/components/SvFilterForm/FrequencyPane.vue
@@ -16,9 +16,9 @@ const sampleCounts = computed(() => {
   const isGRCh38 = props.case?.release === 'GRCh38'
 
   return {
-    thousandGenomes: isGRCh38 ? 0 : 1000,
-    exac: isGRCh38 ? 0 : 60706,
-    gnomadSv: isGRCh38 ? 63046 : 14216,
+    thousandGenomes: 2504, // GRCh37
+    exac: 60706,           // GRCh37
+    gnomadSv: isGRCh38 ? 63046 : 10738,
   }
 })
 

--- a/frontend/src/svs/components/SvFilterForm/FrequencyPane.vue
+++ b/frontend/src/svs/components/SvFilterForm/FrequencyPane.vue
@@ -11,6 +11,17 @@ const props = defineProps({
   querySettings: Object,
 })
 
+// Sample counts for different genome builds.
+const sampleCounts = computed(() => {
+  const isGRCh38 = props.case?.release === 'GRCh38'
+
+  return {
+    thousandGenomes: isGRCh38 ? 0 : 1000,
+    exac: isGRCh38 ? 0 : 60706,
+    gnomadSv: isGRCh38 ? 63046 : 14216,
+  }
+})
+
 // Return JSON string with settings from this tab to be displayed in "dev" mode.
 const dumpFrequencies = () => {
   const result = {}
@@ -160,7 +171,10 @@ defineExpose({
           />
         </td>
         <td title="Phase 3 data (healthy individuals)">
-          1000 Genomes <small class="text-muted">(samples: 1000)</small>
+          1000 Genomes
+          <small class="text-muted"
+            >(samples: {{ sampleCounts.thousandGenomes.toLocaleString() }})</small
+          >
         </td>
         <td>
           <input
@@ -206,7 +220,10 @@ defineExpose({
           />
         </td>
         <td title="Exomes; project attempts to exclude pediatric disease cases">
-          ExAC <small class="text-muted">(samples: 60,706)</small>
+          ExAC
+          <small class="text-muted"
+            >(samples: {{ sampleCounts.exac.toLocaleString() }})</small
+          >
         </td>
         <td>
           <input
@@ -253,7 +270,10 @@ defineExpose({
           />
         </td>
         <td title="genomes; project attempts to exclude pediatric cases">
-          gnomAD-SV <small class="text-muted">(samples: 14,216)</small>
+          gnomAD-SV
+          <small class="text-muted"
+            >(samples: {{ sampleCounts.gnomadSv.toLocaleString() }})</small
+          >
         </td>
         <td>
           <input


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Frequency table sample counts for 1000 Genomes, ExAC, and gnomAD-SV now update based on the selected genome build.
  * Sample numbers are displayed dynamically and locale-formatted for improved readability, replacing previous hardcoded values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->