### PR TITLE
fix: normalize mitochondrial chromosome name for IGV link-outs

### DIFF
--- a/frontend/src/svs/components/StrucvarDetailsNavi/lib.spec.ts
+++ b/frontend/src/svs/components/StrucvarDetailsNavi/lib.spec.ts
@@ -1,0 +1,65 @@
+import {
+  BreakendStrucvarImpl,
+  InsertionStrucvarImpl,
+  LinearStrucvarImpl,
+} from '@bihealth/reev-frontend-lib/lib/genomicVars'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { jumpToLocus } from './lib'
+
+/** Return the locus that `jumpToLocus` requested from IGV. */
+const requestedLocus = (fetchMock: ReturnType<typeof vi.fn>): string => {
+  const url = new URL(fetchMock.mock.calls[0][0] as string)
+  return url.searchParams.get('locus') as string
+}
+
+describe('jumpToLocus', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(new Response())
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  test('does not call IGV without a variant', async () => {
+    await jumpToLocus(undefined)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test('uses the full span for a linear SV', async () => {
+    await jumpToLocus(new LinearStrucvarImpl('DEL', 'grch37', '17', 100, 200))
+
+    expect(requestedLocus(fetchMock)).toBe('17:100-200')
+  })
+
+  test('uses a one-base window for an insertion', async () => {
+    await jumpToLocus(new InsertionStrucvarImpl('grch37', '17', 100))
+
+    expect(requestedLocus(fetchMock)).toBe('17:100-101')
+  })
+
+  test('uses a one-base window on the first breakend for a BND', async () => {
+    await jumpToLocus(new BreakendStrucvarImpl('grch37', '17', '22', 100, 200))
+
+    expect(requestedLocus(fetchMock)).toBe('17:100-101')
+  })
+
+  // Regression: the mitochondrial chromosome reaches us as `MT` on GRCh37 and as
+  // `chrM`/`chrMT` on GRCh38, and the breakend path strips the `chr` prefix.  IGV
+  // only understands `chrM`.
+  test.each(['MT', 'M', 'chrMT', 'chrM'])(
+    'normalizes the mitochondrial chromosome %s to chrM',
+    async (chrom) => {
+      await jumpToLocus(
+        new LinearStrucvarImpl('DEL', 'grch37', chrom, 100, 200),
+      )
+
+      expect(requestedLocus(fetchMock)).toBe('chrM:100-200')
+    },
+  )
+})

--- a/frontend/src/svs/components/StrucvarDetailsNavi/lib.ts
+++ b/frontend/src/svs/components/StrucvarDetailsNavi/lib.ts
@@ -1,4 +1,5 @@
 import { Strucvar } from '@bihealth/reev-frontend-lib/lib/genomicVars'
+import { igvChrom } from '@bihealth/reev-frontend-lib/lib/utils'
 
 /**
  * Jump to the locus in the local IGV.
@@ -8,7 +9,7 @@ export const jumpToLocus = async (strucvar?: Strucvar) => {
     return
   }
   let url: string
-  const chrom = strucvar.chrom == 'chrMT' ? 'chrM' : strucvar.chrom
+  const chrom = igvChrom(strucvar.chrom)
   if (strucvar.svType === 'BND' || strucvar.svType === 'INS') {
     url = `http://127.0.0.1:60151/goto?locus=${chrom}:${strucvar.start ?? 1}-${(strucvar.start ?? 1) + 1}`
   } else {

--- a/frontend/src/svs/components/SvFilterResultsTable.vue
+++ b/frontend/src/svs/components/SvFilterResultsTable.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { LinearStrucvarImpl } from '@bihealth/reev-frontend-lib/lib/genomicVars'
+import { igvChrom } from '@bihealth/reev-frontend-lib/lib/utils'
 import { sortBy } from 'sort-by-typescript'
 import { computed, onBeforeMount, reactive, ref, watch } from 'vue'
 import EasyDataTable from 'vue3-easy-data-table'
@@ -219,7 +220,7 @@ const loadFromServer = async () => {
 }
 
 const goToLocus = async ({ chromosome, start, end }) => {
-  const chrom = chromosome == 'chrMT' ? 'chrM' : chromosome
+  const chrom = igvChrom(chromosome)
   await fetch(`http://127.0.0.1:60151/goto?locus=${chrom}:${start}-${end}`)
 }
 


### PR DESCRIPTION
Closes #2681.

## Problem

The IGV link-out mapped the mitochondrial chromosome to the `chrM` spelling IGV
expects with `chromosome == 'chrMT' ? 'chrM' : chromosome`, which catches only one
of the four spellings that actually reach the call sites. `MT`, `M` and `chrM` all
fell through unchanged, so the link-out failed to navigate for mitochondrial
variants on GRCh37 and for mitochondrial breakends on GRCh38.

See the issue for why all four spellings occur.

## Changes

- Use the `igvChrom()` helper from reev-frontend-lib, which normalizes all four
  spellings, rather than carrying a second implementation here.
- Bump the submodule to `a145a3a`, where that helper was introduced
  (bihealth/reev-frontend-lib#274).
- Add a regression test for the locus handed to IGV. There were previously no tests
  under `src/svs` or `tests/svs` at all.

## Verification

- Full frontend suite green: 58 files, 305 tests.
- `prettier --check` clean; `npm run lint` exit 0.
- `npm run type-check` reports only the pre-existing `plotly.js-dist` error that the
  Makefile's disabled `lint-type-check` refers to.
- The new test was confirmed to **fail** against the old comparison for the `MT` and
  `M` spellings, then pass with the fix.

## Not covered here

The two small-variant call sites (`SeqvarDetailsNavi/lib.ts`,
`variants/components/FilterResultsTable.vue`) have the identical bug and are left for
a follow-up. Note also that `.eslintrc.cjs` excludes `**/svs/**` via a "temporary"
ignore pattern, so the touched files are not linted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved genomic location navigation by consistently normalizing chromosome names, including mitochondrial chromosomes.
  * Ensured structural variant details and filter results open the correct IGV locus.

* **Tests**
  * Added coverage for navigation behavior across linear variants, insertions, breakends, missing variants, and mitochondrial chromosomes.

* **Chores**
  * Updated the frontend library reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->