### PR TITLE
feat: show both breakends in the local IGV link-out

### DIFF
--- a/frontend/src/svs/components/StrucvarDetailsNavi/lib.spec.ts
+++ b/frontend/src/svs/components/StrucvarDetailsNavi/lib.spec.ts
@@ -43,10 +43,18 @@ describe('jumpToLocus', () => {
     expect(requestedLocus(fetchMock)).toBe('17:100-101')
   })
 
-  test('uses a one-base window on the first breakend for a BND', async () => {
+  // A breakend has two breakpoints, potentially on different chromosomes.  Sending both as a
+  // space-delimited locus list makes IGV open them side by side in its multi-locus view.
+  test('uses both breakends for a BND', async () => {
     await jumpToLocus(new BreakendStrucvarImpl('grch37', '17', '22', 100, 200))
 
-    expect(requestedLocus(fetchMock)).toBe('17:100-101')
+    expect(requestedLocus(fetchMock)).toBe('17:100-101 22:200-201')
+  })
+
+  test('normalizes the mitochondrial chromosome on the partner breakend', async () => {
+    await jumpToLocus(new BreakendStrucvarImpl('grch37', '17', 'MT', 100, 200))
+
+    expect(requestedLocus(fetchMock)).toBe('17:100-101 chrM:200-201')
   })
 
   // Regression: the mitochondrial chromosome reaches us as `MT` on GRCh37 and as

--- a/frontend/src/svs/components/StrucvarDetailsNavi/lib.ts
+++ b/frontend/src/svs/components/StrucvarDetailsNavi/lib.ts
@@ -1,5 +1,5 @@
 import { Strucvar } from '@bihealth/reev-frontend-lib/lib/genomicVars'
-import { igvChrom } from '@bihealth/reev-frontend-lib/lib/utils'
+import { igvLocus } from '@bihealth/reev-frontend-lib/lib/utils'
 
 /**
  * Jump to the locus in the local IGV.
@@ -8,13 +8,9 @@ export const jumpToLocus = async (strucvar?: Strucvar) => {
   if (strucvar === undefined) {
     return
   }
-  let url: string
-  const chrom = igvChrom(strucvar.chrom)
-  if (strucvar.svType === 'BND' || strucvar.svType === 'INS') {
-    url = `http://127.0.0.1:60151/goto?locus=${chrom}:${strucvar.start ?? 1}-${(strucvar.start ?? 1) + 1}`
-  } else {
-    url = `http://127.0.0.1:60151/goto?locus=${chrom}:${strucvar.start ?? 1}-${strucvar.stop ?? strucvar.start ?? 1}`
-  }
+  // NB: for breakends this is a space-delimited list of both breakpoints, which makes IGV
+  // open its split-screen view.  The space is percent-encoded by the URL parser in `fetch`.
+  const url = `http://127.0.0.1:60151/goto?locus=${igvLocus(strucvar)}`
   // NB: we allow the call to fetch here as it goes to local IGV.
   await fetch(url).catch((e) => {
     const msg =

--- a/frontend/src/svs/components/SvFilterResultsTable.vue
+++ b/frontend/src/svs/components/SvFilterResultsTable.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { LinearStrucvarImpl } from '@bihealth/reev-frontend-lib/lib/genomicVars'
-import { igvChrom } from '@bihealth/reev-frontend-lib/lib/utils'
+import { igvLocus } from '@bihealth/reev-frontend-lib/lib/utils'
 import { sortBy } from 'sort-by-typescript'
 import { computed, onBeforeMount, reactive, ref, watch } from 'vue'
 import EasyDataTable from 'vue3-easy-data-table'
@@ -8,6 +8,7 @@ import 'vue3-easy-data-table/dist/style.css'
 
 import { useCaseDetailsStore } from '@/cases/stores/caseDetails'
 import { SvClient } from '@/svs/api/strucvarClient'
+import { strucvarFromResultRow } from '@/svs/lib/strucvar'
 import { emptyFlagsTemplate, useSvFlagsStore } from '@/svs/stores/strucvarFlags'
 import { useSvAcmgRatingStore } from '@/svs/stores/svAcmgRating'
 import { useSvCommentsStore } from '@/svs/stores/svComments'
@@ -219,9 +220,11 @@ const loadFromServer = async () => {
   }
 }
 
-const goToLocus = async ({ chromosome, start, end }) => {
-  const chrom = igvChrom(chromosome)
-  await fetch(`http://127.0.0.1:60151/goto?locus=${chrom}:${start}-${end}`)
+const goToLocus = async (svRecord) => {
+  // NB: for breakends this is a space-delimited list of both breakpoints, which makes IGV
+  // open its split-screen view.  The space is percent-encoded by the URL parser in `fetch`.
+  const locus = igvLocus(strucvarFromResultRow(svRecord))
+  await fetch(`http://127.0.0.1:60151/goto?locus=${locus}`)
 }
 
 const ucscUrl = (release, chromosome, start, end) => {

--- a/frontend/src/svs/lib/strucvar.spec.ts
+++ b/frontend/src/svs/lib/strucvar.spec.ts
@@ -1,0 +1,78 @@
+import { igvLocus } from '@bihealth/reev-frontend-lib/lib/utils'
+import { describe, expect, test } from 'vitest'
+
+import { StrucvarResultRow, strucvarFromResultRow } from './strucvar'
+
+/** Build a result row, overriding the given fields. */
+const row = (
+  overrides: Partial<StrucvarResultRow> = {},
+): StrucvarResultRow => ({
+  release: 'GRCh37',
+  chromosome: '17',
+  chromosome2: '17',
+  start: 100,
+  end: 200,
+  sv_type: 'DEL',
+  ...overrides,
+})
+
+describe('strucvarFromResultRow', () => {
+  test('maps a linear SV', () => {
+    const strucvar = strucvarFromResultRow(row({ sv_type: 'DUP' }))
+
+    expect(strucvar).toMatchObject({
+      svType: 'DUP',
+      genomeBuild: 'grch37',
+      chrom: '17',
+      start: 100,
+      stop: 200,
+    })
+  })
+
+  test('maps an insertion to its insertion point', () => {
+    const strucvar = strucvarFromResultRow(row({ sv_type: 'INS' }))
+
+    expect(strucvar).toMatchObject({ svType: 'INS', chrom: '17', start: 100 })
+  })
+
+  test('maps a breakend, keeping the partner end', () => {
+    const strucvar = strucvarFromResultRow(
+      row({ sv_type: 'BND', chromosome2: '22' }),
+    )
+
+    expect(strucvar).toMatchObject({
+      svType: 'BND',
+      chrom: '17',
+      chrom2: '22',
+      start: 100,
+      stop: 200,
+    })
+  })
+
+  test('strips the chr prefix from both ends', () => {
+    const strucvar = strucvarFromResultRow(
+      row({
+        release: 'GRCh38',
+        sv_type: 'BND',
+        chromosome: 'chr17',
+        chromosome2: 'chr22',
+      }),
+    )
+
+    expect(strucvar).toMatchObject({
+      genomeBuild: 'grch38',
+      chrom: '17',
+      chrom2: '22',
+    })
+  })
+
+  // The rows feed straight into `igvLocus`, so pin the loci they produce.
+  test.each([
+    [{ sv_type: 'DEL' }, '17:100-200'],
+    [{ sv_type: 'INS' }, '17:100-101'],
+    [{ sv_type: 'BND', chromosome2: '22' }, '17:100-101 22:200-201'],
+    [{ sv_type: 'BND', chromosome2: 'MT' }, '17:100-101 chrM:200-201'],
+  ])('yields the IGV locus %o -> %s', (overrides, expected) => {
+    expect(igvLocus(strucvarFromResultRow(row(overrides)))).toBe(expected)
+  })
+})

--- a/frontend/src/svs/lib/strucvar.ts
+++ b/frontend/src/svs/lib/strucvar.ts
@@ -1,0 +1,55 @@
+import {
+  BreakendStrucvarImpl,
+  InsertionStrucvarImpl,
+  LinearStrucvarImpl,
+  Strucvar,
+} from '@bihealth/reev-frontend-lib/lib/genomicVars'
+
+/** The fields of an SV query result row that describe the variant's position. */
+export interface StrucvarResultRow {
+  release: string
+  chromosome: string
+  /**
+   * Chromosome of the second end.  The column is nullable in the database, but the
+   * query path always populates it; for linear variants it equals `chromosome`.
+   */
+  chromosome2: string
+  start: number
+  /** End position, on `chromosome2` for breakends and on `chromosome` otherwise. */
+  end: number
+  sv_type: string
+}
+
+/** Strip the `chr` prefix, which GRCh38 chromosome names carry and GRCh37 ones do not. */
+const stripChr = (chromosome: string): string =>
+  chromosome.startsWith('chr') ? chromosome.slice(3) : chromosome
+
+/**
+ * Build the `Strucvar` described by the given SV query result row.
+ *
+ * @param row The result row to convert.
+ * @returns the structural variant the row describes
+ */
+export const strucvarFromResultRow = (row: StrucvarResultRow): Strucvar => {
+  const genomeBuild = row.release === 'GRCh37' ? 'grch37' : 'grch38'
+  const chrom = stripChr(row.chromosome)
+  if (row.sv_type === 'BND') {
+    return new BreakendStrucvarImpl(
+      genomeBuild,
+      chrom,
+      stripChr(row.chromosome2),
+      row.start,
+      row.end,
+    )
+  } else if (row.sv_type === 'INS') {
+    return new InsertionStrucvarImpl(genomeBuild, chrom, row.start)
+  } else {
+    return new LinearStrucvarImpl(
+      row.sv_type as 'DEL' | 'DUP' | 'INV',
+      genomeBuild,
+      chrom,
+      row.start,
+      row.end,
+    )
+  }
+}


### PR DESCRIPTION
Closes #2682.

> **Merge #2683 first.** This PR targets `main` so that the link to #2682 registers,
> which GitHub only does for PRs based on the default branch. As a side effect it
> currently lists #2683's two commits as well; that collapses to just the two breakend
> commits once #2683 merges. Merging this one first would pull #2683's changes in with
> it and leave that PR empty.

## Problem

A breakend has two breakpoints, potentially on different chromosomes, but both IGV
link-outs sent only the first one, so a translocation silently dropped half the
event. The SV results table additionally used `start..end` for BND, which spans two
different chromosomes and is meaningless.

## Changes

- Delegate locus construction to `igvLocus()` from reev-frontend-lib
  (bihealth/reev-frontend-lib#275, PR bihealth/reev-frontend-lib#276), which returns
  both breakpoints as a space-delimited locus list. IGV renders that as a two-panel
  split view. It applies `igvChrom()` to both ends, so the normalization from #2681
  covers the partner breakend too.
- Both call sites now share that one implementation: the SV details sidebar
  (`StrucvarDetailsNavi/lib.ts`) and the SV results table
  (`SvFilterResultsTable.vue`).
- Extract the result-row-to-`Strucvar` mapping into `src/svs/lib/strucvar.ts` so it
  is unit-testable; the results table is a single-file component and cannot be
  imported from a spec.
- Bump the submodule to `6929135`, where `igvLocus` was introduced.

Dropped as part of this: the `start ?? 1` / `stop ?? start ?? 1` fallbacks and a
`Number()` / `isFinite` guard. `Strucvar` types the coordinates as required numbers
and they originate from non-null `IntegerField`s, so none of it was reachable.

## Verification

- Full frontend suite green: 59 files, 314 tests.
- `prettier --check` clean; `npm run lint` exit 0; `type-check` shows only the
  pre-existing `plotly.js-dist` error.
- The IGV syntax was verified against a running IGV separately:
  `GET /goto?locus=9:130713016-130713017%2022:23290413-23290414` returns `204` and
  opens a two-panel split view, both across two chromosomes and on a single one.
  Confirmed here that the URL parser emits exactly that string.

## Out of scope

The other link-outs (UCSC, Ensembl, DGV, VarSome, Franklin) have no split-screen
equivalent. The embedded igv.js browser (`GenomeBrowserCard`) has the same
limitation, but its `locus` prop is a single string and the component lives in the
submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

